### PR TITLE
Add missing requires and PEP8ize.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,17 @@ from distutils.core import setup
 execfile('facebook/version.py')
 
 setup(
-    name = 'Facebook',
-    version = __version__,
-    description = 'Facebook makes it even easier to interact with Facebook\'s Graph API',
-    long_description = open('README.rst').read() + '\n\n' + open('HISTORY.rst').read(),
-    author = 'Johannes Gorset',
-    author_email = 'jgorset@gmail.com',
-    url = 'http://github.com/jgorset/facebook',
-    packages = [
+    name='Facebook',
+    version=__version__,
+    description='Facebook makes it even easier to interact "+\
+                "with Facebook\'s Graph API',
+    long_description=open('README.rst').read() + '\n\n' +
+    open('HISTORY.rst').read(),
+    author='Johannes Gorset',
+    author_email='jgorset@gmail.com',
+    url='http://github.com/jgorset/facebook',
+    requires=['facepy'],
+    packages=[
         'facebook'
     ]
 )


### PR DESCRIPTION
Without this requires setup.py doesn't signal missing dependency and pip install doesn't install it as well resulting in a broken installation.
